### PR TITLE
Bumped rutorrent to 3.9 version and  eliminated the creation of subfolder directories for trackers by default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,8 @@ LABEL build_version="Romancin version:- ${VERSION} Build-date:- ${BUILD_DATE}"
 
 # package version
 ARG MEDIAINF_VER="18.12"
-ARG RTORRENT_VER="v0.9.7"
-ARG LIBTORRENT_VER="v0.13.7"
+ARG RTORRENT_VER="v0.9.6"
+ARG LIBTORRENT_VER="v0.13.6"
 ARG CURL_VER="7.64.0"
 
 # set env

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,15 +9,16 @@ ARG BUILD_CORES
 LABEL build_version="Romancin version:- ${VERSION} Build-date:- ${BUILD_DATE}"
 
 # package version
-ARG MEDIAINF_VER="18.12"
-ARG RTORRENT_VER="0.9.6"
-ARG LIBTORRENT_VER="0.13.6"
+ARG MEDIAINF_VER="19.04"
+ARG RTORRENT_VER="v0.9.7"
+ARG LIBTORRENT_VER="v0.13.7"
 ARG CURL_VER="7.64.1"
 
 # set env
 ENV PKG_CONFIG_PATH=/usr/local/lib/pkgconfig
 ENV LD_LIBRARY_PATH=/usr/local/lib
 ENV CONTEXT_PATH=/
+ENV CREATE_SUBDIR_BY_TRACKERS="no"
     
 RUN NB_CORES=${BUILD_CORES-`getconf _NPROCESSORS_CONF`} && \
  apk add --no-cache \
@@ -55,7 +56,8 @@ RUN NB_CORES=${BUILD_CORES-`getconf _NPROCESSORS_CONF`} && \
         php7-mbstring \
         php7-sockets \
         php7-pear \
-	python && \
+	python \
+	python3 && \
 # install build packages
  apk add --no-cache --virtual=build-dependencies \
         autoconf \
@@ -92,6 +94,7 @@ ldconfig /usr/bin && ldconfig /usr/lib && \
         /defaults/rutorrent-conf/ && \
  rm -rf \
         /defaults/rutorrent-conf/users && \
+ pip3 install CfScrape && \
 # install webui extras
 # QuickBox Theme
 git clone https://github.com/QuickBox/club-QuickBox /usr/share/webapps/rutorrent/plugins/theme/themes/club-QuickBox && \
@@ -133,7 +136,7 @@ svn checkout http://svn.code.sf.net/p/xmlrpc-c/code/stable xmlrpc-c && \
 cd /tmp/xmlrpc-c && \
 ./configure --with-libwww-ssl --disable-wininet-client --disable-curl-client --disable-libwww-client --disable-abyss-server --disable-cgi-server && make -j ${NB_CORES} && make install && \
 # compile libtorrent
-apk add -X http://dl-cdn.alpinelinux.org/alpine/v3.6/main -U cppunit-dev==1.13.2-r1 cppunit==1.13.2-r1 && \
+#apk add -X http://dl-cdn.alpinelinux.org/alpine/v3.6/main -U cppunit-dev==1.13.2-r1 cppunit==1.13.2-r1 && \
 cd /tmp && \
 mkdir libtorrent && \
 cd libtorrent && \
@@ -172,7 +175,7 @@ wget -qO- https://github.com/rakshasa/rtorrent/archive/${RTORRENT_VER}.tar.gz | 
 # cleanup
  apk del --purge \
         build-dependencies && \
- apk del -X http://dl-cdn.alpinelinux.org/alpine/v3.6/main cppunit-dev && \
+ #apk del -X http://dl-cdn.alpinelinux.org/alpine/v3.6/main cppunit-dev && \
  rm -rf \
         /tmp/*
 # add local files

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,8 @@ LABEL build_version="Romancin version:- ${VERSION} Build-date:- ${BUILD_DATE}"
 
 # package version
 ARG MEDIAINF_VER="18.12"
-ARG RTORRENT_VER="v0.9.7"
-ARG LIBTORRENT_VER="v0.13.7"
+ARG RTORRENT_VER="v0.9.4"
+ARG LIBTORRENT_VER="v0.13.4"
 ARG CURL_VER="7.64.0"
 
 # set env

--- a/Dockerfile
+++ b/Dockerfile
@@ -133,7 +133,7 @@ svn checkout http://svn.code.sf.net/p/xmlrpc-c/code/stable xmlrpc-c && \
 cd /tmp/xmlrpc-c && \
 ./configure --with-libwww-ssl --disable-wininet-client --disable-curl-client --disable-libwww-client --disable-abyss-server --disable-cgi-server && make -j ${NB_CORES} && make install && \
 # compile libtorrent
-#apk add -X http://dl-cdn.alpinelinux.org/alpine/v3.6/main -U cppunit-dev==1.13.2-r1 cppunit==1.13.2-r1 && \
+apk add -X http://dl-cdn.alpinelinux.org/alpine/v3.6/main -U cppunit-dev==1.13.2-r1 cppunit==1.13.2-r1 && \
 cd /tmp && \
 mkdir libtorrent && \
 cd libtorrent && \
@@ -172,7 +172,7 @@ wget -qO- https://github.com/rakshasa/rtorrent/archive/${RTORRENT_VER}.tar.gz | 
 # cleanup
  apk del --purge \
         build-dependencies && \
-# apk del -X http://dl-cdn.alpinelinux.org/alpine/v3.6/main cppunit-dev && \
+ apk del -X http://dl-cdn.alpinelinux.org/alpine/v3.6/main cppunit-dev && \
  rm -rf \
         /tmp/*
 # add local files

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,8 @@ LABEL build_version="Romancin version:- ${VERSION} Build-date:- ${BUILD_DATE}"
 
 # package version
 ARG MEDIAINF_VER="18.12"
-ARG RTORRENT_VER="v0.9.6"
-ARG LIBTORRENT_VER="v0.13.6"
+ARG RTORRENT_VER="0.9.6"
+ARG LIBTORRENT_VER="0.13.6"
 ARG CURL_VER="7.64.0"
 
 # set env

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,8 @@ LABEL build_version="Romancin version:- ${VERSION} Build-date:- ${BUILD_DATE}"
 
 # package version
 ARG MEDIAINF_VER="18.12"
-ARG RTORRENT_VER="v0.9.4"
-ARG LIBTORRENT_VER="v0.13.4"
+ARG RTORRENT_VER="0.9.4"
+ARG LIBTORRENT_VER="0.13.4"
 ARG CURL_VER="7.64.0"
 
 # set env

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ A repository for creating a docker container including rtorrent with rutorrent.
 
 You can invite me a beer if you want ;) 
 
+## Description
+
 This is a completely funcional Docker image with rutorrent, rtorrent, libtorrent and a lot of plugins 
 for rutorrent, like autodl-irssi, filemanager, fileshare and other useful ones.
 
@@ -19,15 +21,12 @@ Also installed and selected by default this awesome theme: club-QuickBox
 
 Also includes MaterialDesign theme as an option.
 
-16/03/2018: NEW: rTorrent 0.9.7 / libtorrent 0.13.7 version. rtorrent.rc file has changed completely, rename it before starting with the new image the first time. After first run, add the changes you need to this config file.
-
-05/08/2018: NEW: Includes Pyrocore/rtcontrol - http://pyrocore.readthedocs.io/en/latest/index.html
-
 You need to run pyrocore commands with user "abc", which is who runs rtorrent, so use "su - abc" after connecting container before using pyrocore commands. If you already have torrents in your rtorrent docker instance, you have to add extra information before using pyrocore, check here: http://pyrocore.readthedocs.io/en/latest/setup.html in the "Adding Missing Data to Your rTorrent Session" topic.
 
 Tested and working on Synology and QNAP, but should work on any x86_64 devices.
 
-Instructions: 
+## Instructions
+
 - Map any local port to 443 for SSL rutorrent access (Default username/password is admin/admin) 
 - Map any local port to 51415 for rtorrent 
 - Map a local volume to /config (Stores configuration data, including rtorrent session directory. Consider this on SSD Disk) 
@@ -37,7 +36,7 @@ In order to change rutorrent web access password execute this inside container:
 - `sh -c "echo -n 'admin:' > /config/nginx/.htpasswd"`
 - `sh -c "openssl passwd -apr1 >> /config/nginx/.htpasswd"`
 
-Sample run command:
+## Sample run command
 
 For rtorrent 0.9.7 version:
  
@@ -76,3 +75,36 @@ romancin/rutorrent:0.9.4
 ```
 
 Remember editing `/config/rtorrent/rtorrent.rc` with your own settings, especially your watch subfolder configuration.
+
+## Environment variables supported
+
+List of environment variables:
+| Variable | Function |
+| :----: | --- |
+| PUID | for UserID - see below for explanation |
+| PGID | for GroupID - see below for explanation |
+| TZ | Specify a timezone to use e.g. Europe/Madrid |
+| CREATE_SUBDIR_BY_TRACKERS | YES to create downloads/watch subfolder for trackers (OLD BEHAVIOUR) or NO to create only completed/watch folder (DEFAULT) |
+
+## User / Group Identifiers
+
+When using volumes (`-v` flags) permissions issues can arise between the host OS and the container, we avoid this issue by allowing you to specify the user `PUID` and group `PGID`.
+
+Ensure any volume directories on the host are owned by the same user you specify and any permissions issues will vanish like magic.
+
+In this instance `PUID=1000` and `PGID=1000`, to find yours use `id user` as below:
+
+```
+  $ id username
+    uid=1000(dockeruser) gid=1000(dockergroup) groups=1000(dockergroup)
+```
+
+## Changelog
+
+v2.0 (28/04/2019): Updated image to rutorrent 3.9. For the first time, I have eliminated the creation of subfolder directories for trackers by default. Since this moment, you can choose to create them using CREATE_SUBDIR_BY_TRACKERS variable. 
+
+v1.0.1 (28/03/2019): curl 7.64.0 version has an issue that causes very high CPU usage in rtorrent. This version should fix this behaviour.
+
+v1.0.0 (16/03/2019): NEW: rTorrent 0.9.7 / libtorrent 0.13.7 version. rtorrent.rc file has changed completely, rename it before starting with the new image the first time. After first run, add the changes you need to this config file.
+
+vN/A: 05/08/2018: NEW: Includes Pyrocore/rtcontrol - http://pyrocore.readthedocs.io/en/latest/index.html

--- a/README.md
+++ b/README.md
@@ -78,13 +78,12 @@ Remember editing `/config/rtorrent/rtorrent.rc` with your own settings, especial
 
 ## Environment variables supported
 
-List of environment variables:
 | Variable | Function |
 | :----: | --- |
-| PUID | for UserID - see below for explanation |
-| PGID | for GroupID - see below for explanation |
-| TZ | Specify a timezone to use e.g. Europe/Madrid |
-| CREATE_SUBDIR_BY_TRACKERS | YES to create downloads/watch subfolder for trackers (OLD BEHAVIOUR) or NO to create only completed/watch folder (DEFAULT) |
+| `-e PUID=1000` | for UserID - see below for explanation |
+| `-e PGID=1000` | for GroupID - see below for explanation |
+| `-e TZ=Europe/London` | Specify a timezone to use EG Europe/London. |
+| `-e CREATE_SUBDIR_BY_TRACKERS=YES` | YES to create downloads/watch subfolder for trackers (OLD BEHAVIOUR) or NO to create only completed/watch folder (DEFAULT) |
 
 ## User / Group Identifiers
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,8 @@
 version: '2'
 services:
     rutorrent-develop:
-      image: romancin/rutorrent:develop
-      container_name: rutorrent-develop
+      image: romancin/rutorrent:latest
+      container_name: rutorrent
       networks:
         - default
       tty: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,9 +13,10 @@ services:
         - PUID=0
         - PGID=0
         - TZ=Europe/Madrid
+        - CREATE_SUBDIR_BY_TRACKERS=NO
       ports:
         - "7443:443"
-        - "42316:52316"
+        - "32316:52316"
 networks:
   default:
     external:

--- a/root/defaults/rtorrent.rc
+++ b/root/defaults/rtorrent.rc
@@ -95,13 +95,13 @@ network.xmlrpc.size_limit.set = 4M
 protocol.encryption.set = allow_incoming,try_outgoing,enable_retry
 
 # Set the umask for this process, which is applied to all files created by the program
-system.umask.set = 0027
+system.umask.set = 0022
 
 # Add a preferred filename encoding to the list
 encoding.add = utf8
 
 # Watch a directory for new torrents, and stop those that have been deleted
-schedule2 = watch_directory_99, 1, 10, (cat,"load.start=",(cfg.watch),"*.torrent")
+schedule2 = watch_directory_99,10,10,(cat,"load.start=",(cfg.watch),"*.torrent,d.custom1.set=/downloads/completed/")
 #schedule2 = untied_directory, 5, 5, (cat,"stop_untied=",(cfg.watch),"*.torrent")
 
 # watch subdirectory by tracker
@@ -169,9 +169,8 @@ schedule2 = watch_directory_60,10,10,(cat,"load.start=",(cfg.watch),"/notwhatcd/
 schedule2 = monitor_diskspace, 15, 60, ((close_low_diskspace,1000M))
 
 # Move finished (no need Autotools/Automove plugin on ruTorrent)
-method.insert = d.get_finished_dir, simple, "cat=$cfg.download_complete=,$d.custom1="
 method.insert = d.move_to_complete, simple, "d.directory.set=$argument.1=; execute=mkdir,-p,$argument.1=; execute=mv,-u,$argument.0=,$argument.1=; d.save_full_session="
-method.set_key = event.download.finished,move_complete,"d.move_to_complete=$d.data_path=,$d.get_finished_dir="
+method.set_key = event.download.finished,move_complete,"d.move_to_complete=$d.data_path=,$d.custom1="
 
 # Commit session data
 schedule2 = session_save,240,300,session_save=

--- a/root/defaults/rutorrent-conf/config.php
+++ b/root/defaults/rutorrent-conf/config.php
@@ -45,6 +45,8 @@
 		"gzip"	=> '/usr/bin/gzip',			// Something like /usr/bin/gzip. If empty, will be found in PATH.
 		"id"	=> '/usr/bin/id',			// Something like /usr/bin/id. If empty, will be found in PATH.
 		"stat"	=> '/bin/stat',			// Something like /usr/bin/stat. If empty, will be found in PATH.
+                "pgrep" => '/usr/bin/pgrep',
+                "python" => '/usr/bin/python3',
 	);
 
 	$localhosts = array( 			// list of local interfaces

--- a/root/etc/cont-init.d/20-config
+++ b/root/etc/cont-init.d/20-config
@@ -1,22 +1,34 @@
 #!/usr/bin/with-contenv bash
 
-# make folders (Original)
-# mkdir -p \
-	/config{/log/nginx,/log/rtorrent,/log/rutorrent,/nginx,/nginx/conf.d,/php,/rtorrent/rtorrent_sess,/rutorrent/settings/users} \
-	/config/rutorrent/profiles{/settings,/torrents,/users,/tmp} \
-	/downloads{/completed,/incoming,/watched} \
-	/run{/nginx,/php} \
-	/var/lib/nginx/tmp/client_body
+# Sanitize variables
+SANED_VARS=( CREATE_SUBDIR_BY_TRACKERS )
+for i in "${SANED_VARS[@]}"
+do
+  export echo "$i"="${!i//\"/}"
+  export echo "$i"="$(echo "${!i}" | tr '[:upper:]' '[:lower:]')"
+done
 
-# make folders
-mkdir -p \
+echo "Variable subdir trackers: $CREATE_SUBDIR_BY_TRACKERS" >> /tmp/subdir.txt
+
+if [ "$CREATE_SUBDIR_BY_TRACKERS" == "yes" ]
+then
+  # make folders
+  mkdir -p \
 	/config{/log/nginx,/log/rtorrent,/log/rutorrent,/nginx,/nginx/conf.d,/php,/rtorrent/rtorrent_sess,/rutorrent/settings/users,/.irssi} \
 	/config/rutorrent/profiles{/settings,/torrents,/users,/tmp} \
 	/downloads/{bajaunapeli,bitspyder,torrentfactory,hachede,hdcity,learnflakes,puntotorrent,tbplus,waffles,xbytes,otros,pedros,cinemaggedon,torrentland,tunetraxx,brokenstones,32pages,lztr,p2pelite,bitgamer,psytorrents,pleasuredome,hdspain,iptorrents,trancetraffic,morethantv,passthepopcorn,gp32spain,gazellegames,opencd,mteam,retrowithin,divteam,racingforme,bibliotik,beyondhd,myanonamouse,ultimategamer,x264,awesomehd,broadcasthenet,bitme,theplace,theshow,thegeeks,thevault,theempire,theoccult,torrentleech,hdbits,zonaq,torrentech,sceneaccess,efectodoppler,musicvids,apollo,passtheheadphones,notwhatcd} \
 	/downloads/watch/{bajaunapeli,bitspyder,torrentfactory,hachede,hdcity,learnflakes,puntotorrent,tbplus,waffles,xbytes,otros,pedros,cinemaggedon,torrentland,tunetraxx,brokenstones,32pages,lztr,p2pelite,bitgamer,psytorrents,pleasuredome,hdspain,iptorrents,trancetraffic,morethantv,passthepopcorn,gp32spain,gazellegames,opencd,mteam,retrowithin,divteam,racingforme,bibliotik,beyondhd,myanonamouse,ultimategamer,x264,awesomehd,broadcasthenet,bitme,theplace,theshow,thegeeks,thevault,theempire,theoccult,torrentleech,hdbits,zonaq,torrentech,sceneaccess,efectodoppler,musicvids,apollo,passtheheadphones,notwhatcd} \
 	/run{/nginx,/php} \
 	/var/lib/nginx/tmp/client_body
-
+else
+  # make folders (Original)
+  mkdir -p \
+	/config{/log/nginx,/log/rtorrent,/log/rutorrent,/nginx,/nginx/conf.d,/php,/rtorrent/rtorrent_sess,/rutorrent/settings/users,.irssi} \
+	/config/rutorrent/profiles{/settings,/torrents,/users,/tmp} \
+	/downloads{/completed,/watch} \
+	/run{/nginx,/php} \
+	/var/lib/nginx/tmp/client_body
+fi
 
 # copy config
 PREV_DIR=$(pwd)
@@ -56,12 +68,20 @@ cp /config/php/php.ini /etc/php7/php.ini
 [[ -e /config/rtorrent/rtorrent_sess/rtorrent.lock ]] && \
 	rm /config/rtorrent/rtorrent_sess/rtorrent.lock
 
-# permissions
-chown abc:abc \
+if [ "$CREATE_SUBDIR_BY_TRACKERS" == "yes" ]
+then
+  # permissions
+  chown abc:abc \
 	/downloads \
 	/downloads/watch/{bajaunapeli,bitspyder,torrentfactory,hachede,hdcity,learnflakes,puntotorrent,tbplus,waffles,xbytes,otros,pedros,cinemaggedon,torrentland,tunetraxx,brokenstones,32pages,lztr,p2pelite,bitgamer,psytorrents,pleasuredome,hdspain,iptorrents,trancetraffic,morethantv,passthepopcorn,gp32spain,gazellegames,opencd,mteam,retrowithin,divteam,racingforme,bibliotik,beyondhd,myanonamouse,ultimategamer,x264,awesomehd,broadcasthenet,bitme,theplace,theshow,thegeeks,thevault,theempire,theoccult,torrentleech,hdbits,zonaq,torrentech,sceneaccess,efectodoppler,musicvids,apollo,passtheheadphones,notwhatcd} \
-        /downloads/{bajaunapeli,bitspyder,torrentfactory,hachede,hdcity,learnflakes,puntotorrent,tbplus,waffles,xbytes,otros,pedros,cinemaggedon,torrentland,tunetraxx,brokenstones,32pages,lztr,p2pelite,bitgamer,psytorrents,pleasuredome,hdspain,iptorrents,trancetraffic,morethantv,passthepopcorn,gp32spain,gazellegames,opencd,mteam,retrowithin,divteam,racingforme,bibliotik,beyondhd,myanonamouse,ultimategamer,x264,awesomehd,broadcasthenet,bitme,theplace,theshow,thegeeks,thevault,theempire,theoccult,torrentleech,hdbits,zonaq,torrentech,sceneaccess,efectodoppler,musicvids,apollo,passtheheadphones,notwhatcd} \
-
+        /downloads/{bajaunapeli,bitspyder,torrentfactory,hachede,hdcity,learnflakes,puntotorrent,tbplus,waffles,xbytes,otros,pedros,cinemaggedon,torrentland,tunetraxx,brokenstones,32pages,lztr,p2pelite,bitgamer,psytorrents,pleasuredome,hdspain,iptorrents,trancetraffic,morethantv,passthepopcorn,gp32spain,gazellegames,opencd,mteam,retrowithin,divteam,racingforme,bibliotik,beyondhd,myanonamouse,ultimategamer,x264,awesomehd,broadcasthenet,bitme,theplace,theshow,thegeeks,thevault,theempire,theoccult,torrentleech,hdbits,zonaq,torrentech,sceneaccess,efectodoppler,musicvids,apollo,passtheheadphones,notwhatcd} 
+else
+  # permissions
+  chown abc:abc \
+	/downloads \
+	/downloads/watch/ \
+        /downloads/completed/ 
+fi
 
 chown -R abc:abc \
 	/config \

--- a/root/etc/cont-init.d/30-getautodl
+++ b/root/etc/cont-init.d/30-getautodl
@@ -16,6 +16,7 @@ chown -R abc:abc /usr/share/webapps/rutorrent/plugins/autodl-irssi/)
 
 # get updated trackers for irssi-autodl
 wget --quiet -O /tmp/trackers.zip https://github.com/autodl-community/autodl-trackers/archive/master.zip && \
+[[ ! -d /config/.irssi/scripts/AutodlIrssi/trackers ]] && mkdir -p /config/.irssi/scripts/AutodlIrssi/trackers && \
 cd /config/.irssi/scripts/AutodlIrssi/trackers && \
 unzip -q -o -j /tmp/trackers.zip && \
 rm /tmp/trackers.zip


### PR DESCRIPTION
v2.0 (28/04/2019): Updated image to rutorrent 3.9. For the first time, I have eliminated the creation of subfolder directories for trackers by default. Since this moment, you can choose to create them using CREATE_SUBDIR_BY_TRACKERS variable. 
